### PR TITLE
Add missing copyright header

### DIFF
--- a/Assets/NorthStar/Shaders/Subgraphs/Utility/CubemapProjection.hlsl
+++ b/Assets/NorthStar/Shaders/Subgraphs/Utility/CubemapProjection.hlsl
@@ -1,3 +1,4 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
 #ifndef DIRECTION_TO_UV_PROJECTION_UNITY
 #define DIRECTION_TO_UV_PROJECTION_UNITY
 


### PR DESCRIPTION
Automated repo check-up failed due to a missing copyright header on Assets/NorthStar/Shaders/Subgraphs/Utility/CubemapProjection.hlsl